### PR TITLE
Qinwen/fix weight initialization

### DIFF
--- a/clm/model_utils_tpu.py
+++ b/clm/model_utils_tpu.py
@@ -266,10 +266,11 @@ def setup_model_optimizer(config):
         if config.model.config_path:
             model.apply(model._init_weights)
         
-        for name, param in model.named_parameters():
-            if name in ["layer_norm.weight", "layernorm.weight", "norm.weight"]:
-                param.weight.ones_()
-                logger.info("init ones for layer norm")
+        for layer in model.model.layers:
+            layer.input_layernorm.weight.data.ones_()
+            layer.post_attention_layernorm.weight.data.ones_()
+        model.model.norm.weight.data.ones_()
+
 
     no_decay = ["bias", "layer_norm.weight", "layernorm.weight", "norm.weight"]
     

--- a/clm/model_utils_tpu.py
+++ b/clm/model_utils_tpu.py
@@ -265,6 +265,11 @@ def setup_model_optimizer(config):
     else:
         if config.model.config_path:
             model.apply(model._init_weights)
+        
+        for name, param in model.named_parameters():
+            if name in ["layer_norm.weight", "layernorm.weight", "norm.weight"]:
+                param.weight.ones_()
+                logger.info("init ones for layer norm")
 
     no_decay = ["bias", "layer_norm.weight", "layernorm.weight", "norm.weight"]
     

--- a/clm/model_utils_tpu.py
+++ b/clm/model_utils_tpu.py
@@ -267,9 +267,9 @@ def setup_model_optimizer(config):
             model.apply(model._init_weights)
         
         for layer in model.model.layers:
-            layer.input_layernorm.weight.data.ones_()
-            layer.post_attention_layernorm.weight.data.ones_()
-        model.model.norm.weight.data.ones_()
+            layer.input_layernorm.weight.data.fill_(1.0)
+            layer.post_attention_layernorm.weight.data.fill_(1.0)
+        model.model.norm.weight.data.fill_(1.0)
 
 
     no_decay = ["bias", "layer_norm.weight", "layernorm.weight", "norm.weight"]


### PR DESCRIPTION
Fix layernorm weight initialization.  Ideally the layernorm weight needs to initialized  in https://github.com/huggingface/transformers/blob/main/src/transformers/models/mixtral/modeling_mixtral.py#L491
Will remove this once that code is changed in transformer.
